### PR TITLE
chore: add copyright notice

### DIFF
--- a/src/fc-menuitem.ts
+++ b/src/fc-menuitem.ts
@@ -1,5 +1,21 @@
+/**
+@license Apache-2.0
 
-import "@polymer/iron-icon/iron-icon";
+Copyright (C) 2019 - 2021 Flowing Code
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /**
  * @license
  * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
@@ -13,6 +29,8 @@ import "@polymer/iron-icon/iron-icon";
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+ 
+import "@polymer/iron-icon/iron-icon";
 
 import { customElement, html, LitElement, property, PropertyValues } from 'lit-element';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/src/iron-collapse-button.ts
+++ b/src/iron-collapse-button.ts
@@ -1,3 +1,45 @@
+/**
+@license Apache-2.0
+
+Copyright (C) 2019 - 2021 Flowing Code
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+@license MIT
+
+Copyright (c) 2017 Jacob Phillips
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import { customElement, html, LitElement, property } from 'lit-element';
 import "@polymer/paper-item/paper-icon-item";
 import "@polymer/iron-iconset-svg/iron-iconset-svg";


### PR DESCRIPTION
fc-menuitem.ts is derived from [fc-menuitem.js](https://github.com/FlowingCode/AppLayoutAddon/blob/master/src/main/resources/META-INF/frontend/fc-applayout/fc-menuitem.js) which was licensed under the Apache License by Flowing Code S.A. 

iron-collapse-button.ts is derived from [iron-collapse-button.js](https://github.com/FlowingCode/AppLayoutAddon/blob/master/src/main/resources/META-INF/frontend/iron-collapse-button/iron-collapse-button.js) which was licensed under the Apache License by Flowing Code S.A.  and is based on previous work by Jacob Phillips.

Also: move the copyright notice in fc-menuitem.ts before the imports, since the existing notice was positioned between the first and the second import.
