### PR TITLE
fix: add dependency @polymer/iron-flex-layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "lit-element": "^2.3.1",
     "@polymer/paper-item": "^3.0.1",
+    "@polymer/iron-flex-layout": "^3.0.1",
     "@polymer/iron-collapse": "^3.0.1",
     "@vaadin/vaadin-themable-mixin": "^1.6.2",
     "@polymer/iron-iconset-svg": "^3.0.1",
@@ -79,6 +80,7 @@
     "typescript": "^3.8.3",
     "web-component-analyzer": "^1.0.3",
     "@polymer/paper-item": "^3.0.1",
+    "@polymer/iron-flex-layout": "^3.0.1",
     "@polymer/iron-collapse": "^3.0.1",
     "@vaadin/vaadin-themable-mixin": "^1.6.2",
     "@polymer/iron-iconset-svg": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowingcode/fc-menuitem",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Web Component that displays a hierarchical menu",
   "keywords": [
     "web-components",

--- a/src/iron-collapse-button.ts
+++ b/src/iron-collapse-button.ts
@@ -1,4 +1,5 @@
 import { customElement, html, LitElement, property } from 'lit-element';
+import '@polymer/iron-flex-layout/iron-flex-layout.js';
 import "@polymer/iron-iconset-svg/iron-iconset-svg";
 import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-collapse/iron-collapse.js';

--- a/src/iron-collapse-button.ts
+++ b/src/iron-collapse-button.ts
@@ -1,5 +1,4 @@
 import { customElement, html, LitElement, property } from 'lit-element';
-import "@polymer/paper-item/paper-icon-item";
 import "@polymer/iron-iconset-svg/iron-iconset-svg";
 import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-collapse/iron-collapse.js';


### PR DESCRIPTION
`iron-collapse-button` applies styles `--layout-horizontal` and `--layout-center` that are defined in iron-flex-layout

https://github.com/FlowingCode/fc-menuitem/blob/f00627e7012aae245a1a32f774ce9e9d3fbc6f35/src/iron-collapse-button.ts#L22-L25